### PR TITLE
Initial clang/mac support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         -Wfatal-errors
         -Wno-cast-function-type
     )
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "CLANG" OR CMAKE_CXX_COMPILER_ID STREQUAL "APPLECLANG")
+    set(NC_TOOLS_COMPILE_OPTIONS
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Wshadow
+        -Wconversion
+    )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(NC_TOOLS_COMPILE_OPTIONS
         /W4

--- a/source/ncconvert/builder/BuildOrchestrator.cpp
+++ b/source/ncconvert/builder/BuildOrchestrator.cpp
@@ -32,7 +32,7 @@ BuildOrchestrator::BuildOrchestrator(Config config)
 {
 }
 
-BuildOrchestrator::~BuildOrchestrator() = default;
+BuildOrchestrator::~BuildOrchestrator() noexcept = default;
 
 void BuildOrchestrator::RunBuild()
 {

--- a/source/ncconvert/builder/Builder.cpp
+++ b/source/ncconvert/builder/Builder.cpp
@@ -52,7 +52,7 @@ Builder::Builder()
 {
 }
 
-Builder::~Builder() = default;
+Builder::~Builder() noexcept = default;
 
 auto Builder::Build(asset::AssetType type, const Target& target) -> bool
 {

--- a/source/ncconvert/converters/GeometryConverter.cpp
+++ b/source/ncconvert/converters/GeometryConverter.cpp
@@ -120,7 +120,10 @@ auto ConvertToTriangles(std::span<const aiFace> faces, std::span<const aiVector3
 
 auto ConvertToMeshVertices(const aiMesh* mesh) -> std::vector<nc::asset::MeshVertex>
 {
-    NC_ASSERT(mesh->mNormals && mesh->mTextureCoords && mesh->mTangents && mesh->mBitangents,
+    NC_ASSERT(static_cast<bool>(mesh->mNormals) &&
+              static_cast<bool>(mesh->mTextureCoords) &&
+              static_cast<bool>(mesh->mTangents) &&
+              static_cast<bool>(mesh->mBitangents),
               "Not all required data was generated for mesh conversion");
     auto out = std::vector<nc::asset::MeshVertex>{};
     const auto nVertices = mesh->mNumVertices;
@@ -201,7 +204,7 @@ GeometryConverter::GeometryConverter()
 {
 }
 
-GeometryConverter::~GeometryConverter() = default;
+GeometryConverter::~GeometryConverter() noexcept = default;
 
 auto GeometryConverter::ImportConcaveCollider(const std::filesystem::path& path) -> asset::ConcaveCollider
 {

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,66 +1,68 @@
 set(NC_CONVERT_TEST_COLLATERAL_DIR ${PROJECT_SOURCE_DIR}/test/collateral)
 
 ## Build and Import Tests ###
-add_executable(BuildAndImport_integration_tests
-    BuildAndImport_integration_tests.cpp
-)
+if(NC_TOOLS_BUILD_CONVERTER)
+    add_executable(BuildAndImport_integration_tests
+        BuildAndImport_integration_tests.cpp
+    )
 
-target_compile_options(BuildAndImport_integration_tests
-    PUBLIC
-        ${NC_TOOLS_COMPILE_OPTIONS}
-)
+    target_compile_options(BuildAndImport_integration_tests
+        PUBLIC
+            ${NC_TOOLS_COMPILE_OPTIONS}
+    )
 
-target_compile_definitions(BuildAndImport_integration_tests
-    PRIVATE
-        TEST_COLLATERAL_DIR="${NC_CONVERT_TEST_COLLATERAL_DIR}"
-)
+    target_compile_definitions(BuildAndImport_integration_tests
+        PRIVATE
+            TEST_COLLATERAL_DIR="${NC_CONVERT_TEST_COLLATERAL_DIR}"
+    )
 
-target_include_directories(BuildAndImport_integration_tests
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/test/collateral
-        ${PROJECT_SOURCE_DIR}/test/common
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/include/ncasset
-        ${PROJECT_SOURCE_DIR}/source
-        ${PROJECT_SOURCE_DIR}/source/common
-        ${PROJECT_SOURCE_DIR}/source/ncconvert
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/builder
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/converters
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/utility
-)
+    target_include_directories(BuildAndImport_integration_tests
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/test/collateral
+            ${PROJECT_SOURCE_DIR}/test/common
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/include/ncasset
+            ${PROJECT_SOURCE_DIR}/source
+            ${PROJECT_SOURCE_DIR}/source/common
+            ${PROJECT_SOURCE_DIR}/source/ncconvert
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/builder
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/converters
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/utility
+    )
 
-target_include_directories(BuildAndImport_integration_tests
-    SYSTEM PRIVATE
-        ${PROJECT_SOURCE_DIR}/source/external
-)
+    target_include_directories(BuildAndImport_integration_tests
+        SYSTEM PRIVATE
+            ${PROJECT_SOURCE_DIR}/source/external
+    )
 
-target_sources(BuildAndImport_integration_tests
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/source/ncasset/Deserialize.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncasset/Import.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncasset/RawNcaBuffer.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/GeometryAnalysis.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/Sanitize.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/TextureAnalysis.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/builder/Builder.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/builder/Serialize.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/AudioConverter.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/GeometryConverter.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/TextureConverter.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/BlobSize.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/EnumConversion.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/Path.cpp
-)
+    target_sources(BuildAndImport_integration_tests
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/source/ncasset/Deserialize.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncasset/Import.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncasset/RawNcaBuffer.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/GeometryAnalysis.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/Sanitize.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/TextureAnalysis.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/builder/Builder.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/builder/Serialize.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/AudioConverter.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/GeometryConverter.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/TextureConverter.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/BlobSize.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/EnumConversion.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/Path.cpp
+    )
 
-target_link_libraries(BuildAndImport_integration_tests
-    PRIVATE
-        gtest_main
-        NcMath
-        assimp::assimp
-)
+    target_link_libraries(BuildAndImport_integration_tests
+        PRIVATE
+            gtest_main
+            NcMath
+            assimp::assimp
+    )
 
-add_test(BuildAndImport_integration_tests BuildAndImport_integration_tests)
+    add_test(BuildAndImport_integration_tests BuildAndImport_integration_tests)
+endif()
 
 ## NcConvert Integration Tests ##
 if(NC_TOOLS_BUILD_CONVERTER)

--- a/test/integration/NcConvert_integration_tests.cpp
+++ b/test/integration/NcConvert_integration_tests.cpp
@@ -20,10 +20,13 @@ const auto ncaTestOutDirectory = collateral::collateralDirectory / "test_temp_di
 
 auto RunCmd(const std::string& cmd) -> int
 {
+    auto result = std::system(cmd.c_str());
+
 #ifdef WIN32
-    return std::system(cmd.c_str());
+    return result;
 #else
-    return WEXITSTATUS(std::system(cmd.c_str()));
+    // note: At least on Mac, this takes the address of the arg, so we need to pass a local var.
+    return WEXITSTATUS(result);
 #endif
 }
 

--- a/test/ncconvert/CMakeLists.txt
+++ b/test/ncconvert/CMakeLists.txt
@@ -71,44 +71,46 @@ target_link_libraries(EnumConversion_unit_tests
 add_test(EnumConversion_unit_tests EnumConversion_unit_tests)
 
 ## GeometryConverter Tests ###
-add_executable(GeometryConverter_unit_tests
-    GeometryConverter_unit_tests.cpp
-)
+if(NC_TOOLS_BUILD_CONVERTER)
+    add_executable(GeometryConverter_unit_tests
+        GeometryConverter_unit_tests.cpp
+    )
 
-target_compile_options(GeometryConverter_unit_tests
-    PUBLIC
-        ${NC_TOOLS_COMPILE_OPTIONS}
-)
+    target_compile_options(GeometryConverter_unit_tests
+        PUBLIC
+            ${NC_TOOLS_COMPILE_OPTIONS}
+    )
 
-target_compile_definitions(GeometryConverter_unit_tests
-    PRIVATE
-        TEST_COLLATERAL_DIR="${NC_CONVERT_TEST_COLLATERAL_DIR}"
-)
+    target_compile_definitions(GeometryConverter_unit_tests
+        PRIVATE
+            TEST_COLLATERAL_DIR="${NC_CONVERT_TEST_COLLATERAL_DIR}"
+    )
 
-target_include_directories(GeometryConverter_unit_tests
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/test/collateral
-        ${PROJECT_SOURCE_DIR}/test/common
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/source/ncconvert
-)
+    target_include_directories(GeometryConverter_unit_tests
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/test/collateral
+            ${PROJECT_SOURCE_DIR}/test/common
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/source/ncconvert
+    )
 
-target_sources(GeometryConverter_unit_tests
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/GeometryAnalysis.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/Sanitize.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/GeometryConverter.cpp
-        ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/Path.cpp
-)
+    target_sources(GeometryConverter_unit_tests
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/GeometryAnalysis.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/analysis/Sanitize.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/converters/GeometryConverter.cpp
+            ${PROJECT_SOURCE_DIR}/source/ncconvert/utility/Path.cpp
+    )
 
-target_link_libraries(GeometryConverter_unit_tests
-    PRIVATE
-        gtest_main
-        NcMath
-        assimp::assimp
-)
+    target_link_libraries(GeometryConverter_unit_tests
+        PRIVATE
+            gtest_main
+            NcMath
+            assimp::assimp
+    )
 
-add_test(GeometryConverter_unit_tests GeometryConverter_unit_tests)
+    add_test(GeometryConverter_unit_tests GeometryConverter_unit_tests)
+endif()
 
 ## GeometryAnalysis Tests ###
 add_executable(GeometryAnalysis_unit_tests


### PR DESCRIPTION
Addressing issues found while building on macOS. Can't add a CI build yet, but it should be straight forward once clang 16 is available on the build agents.