### PR TITLE
Use exact dependency version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ include(FetchContent)
 
 FetchContent_Declare(NcCommon
                      GIT_REPOSITORY https://github.com/NcStudios/NcCommon.git
-                     GIT_TAG        origin/vnext
+                     GIT_TAG        6de43adb1bc310cbf368cf3ac6ebe467dc9ed846 # origin/vnext
                      GIT_SHALLOW    TRUE
 )
 

--- a/source/ncconvert/CMakeLists.txt
+++ b/source/ncconvert/CMakeLists.txt
@@ -12,7 +12,7 @@ set(ASSIMP_BUILD_OBJ_IMPORTER ON CACHE BOOL "" FORCE)
 
 FetchContent_Declare(assimp
                      GIT_REPOSITORY https://github.com/NcStudios/assimp.git
-                     GIT_TAG        origin/master
+                     GIT_TAG        e4370fda0f4e92d77381dc787ac8a9cab5971f8a # origin/master
                      GIT_SHALLOW    TRUE
 )
 


### PR DESCRIPTION
part of [#422](https://github.com/NcStudios/NcEngine/issues/422)

Targeting exact versions of dependencies so we can always build from previous commits.