### PR TITLE
Include version in asset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           - name: Linux
             os: ubuntu-22.04
             generator: "Unix Makefiles"
-            env: "CXX=/usr/bin/g++-12"
+            env: "CXX=/usr/bin/g++-13"
             definitions: "-DCMAKE_BUILD_TYPE=Debug"
             artifactName: "nc-convert-ubuntu22.04-x64"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
 
 env:
-  VERSION: '3.2.0'
+  VERSION: '4.0.0'
 
 jobs:
   Build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
         type: boolean
 
 env:
-  VERSION: '3.1.0'
+  VERSION: '3.2.0'
 
 jobs:
   Build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
-project("nc-tools" VERSION "3.1.0" LANGUAGES CXX)
+project("nc-tools" VERSION "3.2.0" LANGUAGES CXX)
 
 if(${PROJECT_SOURCE_DIR} EQUAL ${PROJECT_BINARY_DIR})
     message(FATAL_ERROR "Don't be a fool, out-of-source build with your tool.")
 endif()
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 option(NC_TOOLS_BUILD_CONVERTER "Build nc-convert executable" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project("nc-tools" VERSION "3.2.0" LANGUAGES CXX)
+project("nc-tools" VERSION "4.0.0" LANGUAGES CXX)
 
 if(${PROJECT_SOURCE_DIR} EQUAL ${PROJECT_BINARY_DIR})
     message(FATAL_ERROR "Don't be a fool, out-of-source build with your tool.")

--- a/docs/AssetFormats.md
+++ b/docs/AssetFormats.md
@@ -27,7 +27,7 @@ an asset blob, the layout of which is determined by the asset type.
 |--------------|---------|--------------|------
 | magic number | string  | 4            | non-null-terminated string identifying the asset type
 | compression  | string  | 4            | NONE until supported
-| asset id     | u64     | 8            | 
+| version      | u64     | 8            | major version of nc-convert used to create the asset
 | blob size    | u64     | 8            | size of the asset blob
 | asset blob   | -       | blob size    | unique layout for each asset type
 

--- a/include/ncasset/NcaHeader.h
+++ b/include/ncasset/NcaHeader.h
@@ -8,8 +8,8 @@
 
 namespace nc::asset
 {
-constexpr auto version3 = 3ull;
-constexpr auto currentVersion = version3;
+constexpr auto version4 = 4ull;
+constexpr auto currentVersion = version4;
 
 /** @brief Identifiers for asset blobs in .nca files. */
 struct MagicNumber

--- a/include/ncasset/NcaHeader.h
+++ b/include/ncasset/NcaHeader.h
@@ -2,12 +2,15 @@
 
 #include "AssetType.h"
 
-#include <cstddef>
+#include <cstdint>
 #include <iosfwd>
 #include <string_view>
 
 namespace nc::asset
 {
+constexpr auto version3 = 3ull;
+constexpr auto currentVersion = version3;
+
 /** @brief Identifiers for asset blobs in .nca files. */
 struct MagicNumber
 {
@@ -37,14 +40,17 @@ struct NcaHeader
     char compressionAlgorithm[5] = "NONE";
 
     /** @brief The Fnv1a hash of the asset's friendly name. */
-    size_t assetId = 0;
+    uint64_t version = currentVersion;
 
     /** @brief Size in bytes of the asset blob following this header. */
-    size_t size = 0;
+    uint64_t size = 0;
 };
 
 /** @brief Get the AssetType for an NcaHeader. */
 auto GetAssetType(const NcaHeader& header) -> AssetType;
+
+/** @brief Check if deserialization is supported for an Nca version. */
+auto IsVersionSupported(uint64_t version) noexcept -> bool;
 
 /** @brief Serialize an NcaHeader to a stream. */
 void Serialize(std::ostream& stream, const NcaHeader& header);

--- a/source/ncasset/Deserialize.cpp
+++ b/source/ncasset/Deserialize.cpp
@@ -27,6 +27,14 @@ void ValidateHeader(const nc::asset::NcaHeader& header, std::string_view expecte
             header.compressionAlgorithm
         ));
     }
+
+    if (!nc::asset::IsVersionSupported(header.version))
+    {
+        throw nc::NcError(fmt::format(
+            "Unsupported asset version: '{}'",
+            header.version
+        ));
+    }
 }
 
 template<class T>

--- a/source/ncasset/Import.cpp
+++ b/source/ncasset/Import.cpp
@@ -1,4 +1,4 @@
-#include "Import.h"
+#include "ncasset/Import.h"
 #include "Deserialize.h"
 
 #include "ncutility/NcError.h"

--- a/source/ncasset/NcaHeader.cpp
+++ b/source/ncasset/NcaHeader.cpp
@@ -44,7 +44,7 @@ auto GetAssetType(const NcaHeader& header) -> AssetType
 
 auto IsVersionSupported(uint64_t version) noexcept -> bool
 {
-    static constexpr auto supportedVersions = {nc::asset::version3};
+    static constexpr auto supportedVersions = {nc::asset::version4};
     return std::ranges::contains(supportedVersions, version);
 }
 

--- a/source/ncconvert/builder/Builder.cpp
+++ b/source/ncconvert/builder/Builder.cpp
@@ -8,6 +8,7 @@
 #include "utility/Log.h"
 
 #include "ncasset/Assets.h"
+#include "ncasset/NcaHeader.h"
 
 #include "fmt/format.h"
 #include "ncutility/Hash.h"
@@ -36,12 +37,6 @@ auto OpenOutFile(const std::filesystem::path& outPath) -> std::ofstream
 
     return outFile;
 }
-
-auto GetAssetId(const std::filesystem::path& outPath) -> size_t
-{
-    const auto ncaName = outPath.filename();
-    return nc::utility::Fnv1a(ncaName.string());
-}
 } // anonymous namespace
 
 namespace nc::convert
@@ -58,37 +53,36 @@ Builder::~Builder() noexcept = default;
 auto Builder::Build(asset::AssetType type, const Target& target) -> bool
 {
     auto outFile = ::OpenOutFile(target.destinationPath);
-    const auto assetId = ::GetAssetId(target.destinationPath);
     switch (type)
     {
         case asset::AssetType::AudioClip:
         {
             const auto asset = m_audioConverter->ImportAudioClip(target.sourcePath);
-            convert::Serialize(outFile, asset, assetId);
+            convert::Serialize(outFile, asset, asset::currentVersion);
             return true;
         }
         case asset::AssetType::CubeMap:
         {
             const auto asset = m_textureConverter->ImportCubeMap(target.sourcePath);
-            convert::Serialize(outFile, asset, assetId);
+            convert::Serialize(outFile, asset, asset::currentVersion);
             return true;
         }
         case asset::AssetType::ConcaveCollider:
         {
             const auto asset = m_geometryConverter->ImportConcaveCollider(target.sourcePath);
-            convert::Serialize(outFile, asset, assetId);
+            convert::Serialize(outFile, asset, asset::currentVersion);
             return true;
         }
         case asset::AssetType::HullCollider:
         {
             const auto asset = m_geometryConverter->ImportHullCollider(target.sourcePath);
-            convert::Serialize(outFile, asset, assetId);
+            convert::Serialize(outFile, asset, asset::currentVersion);
             return true;
         }
         case asset::AssetType::Mesh:
         {
             const auto asset = m_geometryConverter->ImportMesh(target.sourcePath, target.subResourceName);
-            convert::Serialize(outFile, asset, assetId);
+            convert::Serialize(outFile, asset, asset::currentVersion);
             return true;
         }
         case asset::AssetType::Shader:
@@ -98,13 +92,13 @@ auto Builder::Build(asset::AssetType type, const Target& target) -> bool
         case asset::AssetType::SkeletalAnimation:
         {
             const auto asset = m_geometryConverter->ImportSkeletalAnimation(target.sourcePath, target.subResourceName);
-            convert::Serialize(outFile, asset, assetId);
+            convert::Serialize(outFile, asset, asset::currentVersion);
             return true;
         }
         case asset::AssetType::Texture:
         {
             const auto asset = m_textureConverter->ImportTexture(target.sourcePath);
-            convert::Serialize(outFile, asset, assetId);
+            convert::Serialize(outFile, asset, asset::currentVersion);
             return true;
         }
         case asset::AssetType::Font:

--- a/source/ncconvert/builder/Inspect.cpp
+++ b/source/ncconvert/builder/Inspect.cpp
@@ -12,7 +12,7 @@ R"(File {}
 Header
   magic number {}
   compression  {}
-  id           {}
+  version      {}
   size         {})";
 
 constexpr auto audioClipTemplate =
@@ -64,7 +64,12 @@ void Inspect(const std::filesystem::path& ncaPath)
 {
     const auto header = asset::ImportNcaHeader(ncaPath);
     const auto type = GetAssetType(header);
-    LOG(headerTemplate, ncaPath.string(), header.magicNumber, header.compressionAlgorithm, header.assetId, header.size);
+    LOG(headerTemplate, ncaPath.string(), header.magicNumber, header.compressionAlgorithm, header.version, header.size);
+    if (!asset::IsVersionSupported(header.version))
+    {
+        LOG("Unsupported asset version {}", header.version);
+        return;
+    }
 
     switch (type)
     {

--- a/source/ncconvert/builder/Serialize.cpp
+++ b/source/ncconvert/builder/Serialize.cpp
@@ -11,9 +11,9 @@
 namespace
 {
 template<class T>
-void SerializeImpl(std::ostream& stream, const T& data, std::string_view magicNumber, size_t assetId)
+void SerializeImpl(std::ostream& stream, const T& data, std::string_view magicNumber, uint64_t version)
 {
-    auto header = nc::asset::NcaHeader{"", "NONE", assetId, nc::convert::GetBlobSize(data)};
+    auto header = nc::asset::NcaHeader{"", "NONE", version, nc::convert::GetBlobSize(data)};
     std::memcpy(header.magicNumber, magicNumber.data(), 5);
     nc::serialize::Serialize(stream, header);
     nc::serialize::Serialize(stream, data);
@@ -22,38 +22,38 @@ void SerializeImpl(std::ostream& stream, const T& data, std::string_view magicNu
 
 namespace nc::convert
 {
-void Serialize(std::ostream& stream, const asset::AudioClip& data, size_t assetId)
+void Serialize(std::ostream& stream, const asset::AudioClip& data, uint64_t version)
 {
-    SerializeImpl(stream, data, asset::MagicNumber::audioClip, assetId);
+    SerializeImpl(stream, data, asset::MagicNumber::audioClip, version);
 }
 
-void Serialize(std::ostream& stream, const asset::ConcaveCollider& data, size_t assetId)
+void Serialize(std::ostream& stream, const asset::ConcaveCollider& data, uint64_t version)
 {
-    SerializeImpl(stream, data, asset::MagicNumber::concaveCollider, assetId);
+    SerializeImpl(stream, data, asset::MagicNumber::concaveCollider, version);
 }
 
-void Serialize(std::ostream& stream, const asset::CubeMap& data, size_t assetId)
+void Serialize(std::ostream& stream, const asset::CubeMap& data, uint64_t version)
 {
-    SerializeImpl(stream, data, asset::MagicNumber::cubeMap, assetId);
+    SerializeImpl(stream, data, asset::MagicNumber::cubeMap, version);
 }
 
-void Serialize(std::ostream& stream, const asset::HullCollider& data, size_t assetId)
+void Serialize(std::ostream& stream, const asset::HullCollider& data, uint64_t version)
 {
-    SerializeImpl(stream, data, asset::MagicNumber::hullCollider, assetId);
+    SerializeImpl(stream, data, asset::MagicNumber::hullCollider, version);
 }
 
-void Serialize(std::ostream& stream, const asset::Mesh& data, size_t assetId)
+void Serialize(std::ostream& stream, const asset::Mesh& data, uint64_t version)
 {
-    SerializeImpl(stream, data, asset::MagicNumber::mesh, assetId);
+    SerializeImpl(stream, data, asset::MagicNumber::mesh, version);
 }
 
-void Serialize(std::ostream& stream, const asset::SkeletalAnimation& data, size_t assetId)
+void Serialize(std::ostream& stream, const asset::SkeletalAnimation& data, uint64_t version)
 {
-    SerializeImpl(stream, data, asset::MagicNumber::skeletalAnimation, assetId);
+    SerializeImpl(stream, data, asset::MagicNumber::skeletalAnimation, version);
 }
 
-void Serialize(std::ostream& stream, const asset::Texture& data, size_t assetId)
+void Serialize(std::ostream& stream, const asset::Texture& data, uint64_t version)
 {
-    SerializeImpl(stream, data, asset::MagicNumber::texture, assetId);
+    SerializeImpl(stream, data, asset::MagicNumber::texture, version);
 }
 } // namespace nc::convert

--- a/source/ncconvert/builder/Serialize.h
+++ b/source/ncconvert/builder/Serialize.h
@@ -2,28 +2,29 @@
 
 #include "ncasset/AssetsFwd.h"
 
+#include <cstdint>
 #include <iosfwd>
 
 namespace nc::convert
 {
 /** @brief Write an AudioClip to a binary stream. */
-void Serialize(std::ostream& stream, const asset::AudioClip& data, size_t assetId);
+void Serialize(std::ostream& stream, const asset::AudioClip& data, uint64_t version);
 
 /** @brief Write a ConcaveCollider to a binary stream. */
-void Serialize(std::ostream& stream, const asset::ConcaveCollider& data, size_t assetId);
+void Serialize(std::ostream& stream, const asset::ConcaveCollider& data, uint64_t version);
 
 /** @brief Write a CubeMap to a binary stream. */
-void Serialize(std::ostream& stream, const asset::CubeMap& data, size_t assetId);
+void Serialize(std::ostream& stream, const asset::CubeMap& data, uint64_t version);
 
 /** @brief Write a HullCollider to a binary stream. */
-void Serialize(std::ostream& stream, const asset::HullCollider& data, size_t assetId);
+void Serialize(std::ostream& stream, const asset::HullCollider& data, uint64_t version);
 
 /** @brief Write a Mesh to a binary stream. */
-void Serialize(std::ostream& stream, const asset::Mesh& data, size_t assetId);
+void Serialize(std::ostream& stream, const asset::Mesh& data, uint64_t version);
 
 /** @brief Write a SkeletalAnimation to a binary stream. */
-void Serialize(std::ostream& stream, const asset::SkeletalAnimation& data, size_t assetId);
+void Serialize(std::ostream& stream, const asset::SkeletalAnimation& data, uint64_t version);
 
 /** @brief Write a Texture to a binary stream. */
-void Serialize(std::ostream& stream, const asset::Texture& data, size_t assetId);
+void Serialize(std::ostream& stream, const asset::Texture& data, uint64_t version);
 } // nc::convert

--- a/test/integration/Serialize_integration_tests.cpp
+++ b/test/integration/Serialize_integration_tests.cpp
@@ -5,6 +5,7 @@
 #include "ncasset/Assets.h"
 
 #include "ncmath/Math.h"
+#include "ncutility/NcError.h"
 
 #include <algorithm>
 #include <sstream>
@@ -49,7 +50,7 @@ bool Equals(const DirectX::XMMATRIX& lhs, const DirectX::XMMATRIX& rhs)
 
 TEST(SerializationTest, HullCollider_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
     const auto expectedAsset = nc::asset::HullCollider{
         .extents = nc::Vector3{1.2f, 3.4f, 5.6f},
         .maxExtent = 42.42f,
@@ -60,11 +61,11 @@ TEST(SerializationTest, HullCollider_roundTrip_succeeds)
     };
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeHullCollider(stream);
 
     EXPECT_STREQ("HULL", actualHeader.magicNumber);
-    EXPECT_EQ(assetId, actualHeader.assetId);
+    EXPECT_EQ(version, actualHeader.version);
     EXPECT_EQ(nc::convert::GetBlobSize(expectedAsset), actualHeader.size);
     EXPECT_STREQ("NONE", actualHeader.compressionAlgorithm);
 
@@ -78,7 +79,7 @@ TEST(SerializationTest, HullCollider_roundTrip_succeeds)
 
 TEST(SerializationTest, ConcaveCollider_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
     const auto expectedAsset = nc::asset::ConcaveCollider{
         .extents = nc::Vector3{-1.1f, 2.2f, -3.3f},
         .maxExtent = 123.321f,
@@ -89,11 +90,11 @@ TEST(SerializationTest, ConcaveCollider_roundTrip_succeeds)
     };
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeConcaveCollider(stream);
 
     EXPECT_STREQ("CONC", actualHeader.magicNumber);
-    EXPECT_EQ(assetId, actualHeader.assetId);
+    EXPECT_EQ(version, actualHeader.version);
     EXPECT_EQ(nc::convert::GetBlobSize(expectedAsset), actualHeader.size);
     EXPECT_STREQ("NONE", actualHeader.compressionAlgorithm);
 
@@ -113,7 +114,7 @@ TEST(SerializationTest, ConcaveCollider_roundTrip_succeeds)
 
 TEST(SerializationTest, Mesh_hasBones_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
     auto expectedAsset = nc::asset::Mesh{
         .extents = nc::Vector3{-5.0f, 4.22f, 10.010101f},
         .maxExtent = 10.010101f,
@@ -184,11 +185,11 @@ TEST(SerializationTest, Mesh_hasBones_roundTrip_succeeds)
     expectedAsset.bonesData.value().boneMapping.emplace("Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0Bone0", 0);
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeMesh(stream);
 
     EXPECT_STREQ("MESH", actualHeader.magicNumber);
-    EXPECT_EQ(assetId, actualHeader.assetId);
+    EXPECT_EQ(version, actualHeader.version);
     EXPECT_EQ(nc::convert::GetBlobSize(expectedAsset), actualHeader.size);
     EXPECT_STREQ("NONE", actualHeader.compressionAlgorithm);
 
@@ -221,7 +222,7 @@ TEST(SerializationTest, Mesh_hasBones_roundTrip_succeeds)
 
 TEST(SerializationTest, Mesh_noBones_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
     const auto expectedAsset = nc::asset::Mesh{
         .extents = nc::Vector3{-5.0f, 4.22f, 10.010101f},
         .maxExtent = 10.010101f,
@@ -255,11 +256,11 @@ TEST(SerializationTest, Mesh_noBones_roundTrip_succeeds)
     };
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeMesh(stream);
 
     EXPECT_STREQ("MESH", actualHeader.magicNumber);
-    EXPECT_EQ(assetId, actualHeader.assetId);
+    EXPECT_EQ(version, actualHeader.version);
     EXPECT_EQ(nc::convert::GetBlobSize(expectedAsset), actualHeader.size);
     EXPECT_STREQ("NONE", actualHeader.compressionAlgorithm);
 
@@ -284,7 +285,7 @@ TEST(SerializationTest, Mesh_noBones_roundTrip_succeeds)
 
 TEST(SerializationTest, Texture_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
     const auto expectedAsset = nc::asset::Texture{
         .width = 2, .height = 2,
         .pixelData = std::vector<unsigned char>{
@@ -294,11 +295,11 @@ TEST(SerializationTest, Texture_roundTrip_succeeds)
     };
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeTexture(stream);
 
     EXPECT_STREQ("TEXT", actualHeader.magicNumber);
-    EXPECT_EQ(assetId, actualHeader.assetId);
+    EXPECT_EQ(version, actualHeader.version);
     EXPECT_EQ(nc::convert::GetBlobSize(expectedAsset), actualHeader.size);
     EXPECT_STREQ("NONE", actualHeader.compressionAlgorithm);
 
@@ -313,7 +314,7 @@ TEST(SerializationTest, Texture_roundTrip_succeeds)
 
 TEST(SerializationTest, AudioClip_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
     const auto expectedAsset = nc::asset::AudioClip{
         .samplesPerChannel = 4ull,
         .leftChannel = std::vector<double>{0.0f, 0.5f, 1.0f, 0.5f},
@@ -321,11 +322,11 @@ TEST(SerializationTest, AudioClip_roundTrip_succeeds)
     };
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeAudioClip(stream);
 
     EXPECT_STREQ("CLIP", actualHeader.magicNumber);
-    EXPECT_EQ(assetId, actualHeader.assetId);
+    EXPECT_EQ(version, actualHeader.version);
     EXPECT_EQ(nc::convert::GetBlobSize(expectedAsset), actualHeader.size);
     EXPECT_STREQ("NONE", actualHeader.compressionAlgorithm);
 
@@ -342,7 +343,7 @@ TEST(SerializationTest, AudioClip_roundTrip_succeeds)
 
 TEST(SerializationTest, CubeMap_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
     const auto expectedAsset = nc::asset::CubeMap{
         .faceSideLength = 1,
         .pixelData = std::vector<unsigned char>{
@@ -356,11 +357,11 @@ TEST(SerializationTest, CubeMap_roundTrip_succeeds)
     };
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeCubeMap(stream);
 
     EXPECT_STREQ("CUBE", actualHeader.magicNumber);
-    EXPECT_EQ(assetId, actualHeader.assetId);
+    EXPECT_EQ(version, actualHeader.version);
     EXPECT_EQ(nc::convert::GetBlobSize(expectedAsset), actualHeader.size);
     EXPECT_STREQ("NONE", actualHeader.compressionAlgorithm);
 
@@ -374,7 +375,7 @@ TEST(SerializationTest, CubeMap_roundTrip_succeeds)
 
 TEST(SerializationTest, SkeletalAnimation_roundTrip_succeeds)
 {
-    constexpr auto assetId = 1234ull;
+    constexpr auto version = nc::asset::currentVersion;
 
     const auto firstBoneFrame = nc::asset::SkeletalAnimationFrames
     {
@@ -438,7 +439,7 @@ TEST(SerializationTest, SkeletalAnimation_roundTrip_succeeds)
     };
 
     auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
-    nc::convert::Serialize(stream, expectedAsset, assetId);
+    nc::convert::Serialize(stream, expectedAsset, version);
     const auto [actualHeader, actualAsset] = nc::asset::DeserializeSkeletalAnimation(stream);
 
     EXPECT_EQ(actualAsset.name, std::string{"Test"});
@@ -475,4 +476,67 @@ TEST(SerializationTest, SkeletalAnimation_roundTrip_succeeds)
     EXPECT_FLOAT_EQ(secondBoneFrames.scaleFrames.at(2).scale.x, 5.2f);
     EXPECT_FLOAT_EQ(secondBoneFrames.scaleFrames.at(2).scale.y, 5.2f);
     EXPECT_FLOAT_EQ(secondBoneFrames.scaleFrames.at(2).scale.z, 5.2f);
+}
+
+TEST(SerializationTest, DeserializeAudioClip_unsupportedVersion_throws)
+{
+    const auto dummyAsset = nc::asset::AudioClip{};
+    const auto unsupportedVersion = 1ull;
+    auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
+    nc::convert::Serialize(stream, dummyAsset, unsupportedVersion);
+    EXPECT_THROW(nc::asset::DeserializeAudioClip(stream), nc::NcError);
+}
+
+TEST(SerializationTest, DeserializeConcaveCollider_unsupportedVersion_throws)
+{
+    const auto dummyAsset = nc::asset::ConcaveCollider{};
+    const auto unsupportedVersion = 1ull;
+    auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
+    nc::convert::Serialize(stream, dummyAsset, unsupportedVersion);
+    EXPECT_THROW(nc::asset::DeserializeConcaveCollider(stream), nc::NcError);
+}
+
+TEST(SerializationTest, DeserializeCubeMap_unsupportedVersion_throws)
+{
+    const auto dummyAsset = nc::asset::CubeMap{};
+    const auto unsupportedVersion = 1ull;
+    auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
+    nc::convert::Serialize(stream, dummyAsset, unsupportedVersion);
+    EXPECT_THROW(nc::asset::DeserializeCubeMap(stream), nc::NcError);
+}
+
+TEST(SerializationTest, DeserializeHullCollider_unsupportedVersion_throws)
+{
+    const auto dummyAsset = nc::asset::HullCollider{};
+    const auto unsupportedVersion = 1ull;
+    auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
+    nc::convert::Serialize(stream, dummyAsset, unsupportedVersion);
+    EXPECT_THROW(nc::asset::DeserializeHullCollider(stream), nc::NcError);
+}
+
+TEST(SerializationTest, DeserializeMesh_unsupportedVersion_throws)
+{
+    const auto dummyAsset = nc::asset::Mesh{};
+    const auto unsupportedVersion = 1ull;
+    auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
+    nc::convert::Serialize(stream, dummyAsset, unsupportedVersion);
+    EXPECT_THROW(nc::asset::DeserializeMesh(stream), nc::NcError);
+}
+
+TEST(SerializationTest, DeserializeSkeletalAnimation_unsupportedVersion_throws)
+{
+    const auto dummyAsset = nc::asset::SkeletalAnimation{};
+    const auto unsupportedVersion = 1ull;
+    auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
+    nc::convert::Serialize(stream, dummyAsset, unsupportedVersion);
+    EXPECT_THROW(nc::asset::DeserializeSkeletalAnimation(stream), nc::NcError);
+}
+
+TEST(SerializationTest, DeserializeTexture_unsupportedVersion_throws)
+{
+    const auto dummyAsset = nc::asset::Texture{};
+    const auto unsupportedVersion = 1ull;
+    auto stream = std::stringstream{std::ios::in | std::ios::out | std::ios::binary};
+    nc::convert::Serialize(stream, dummyAsset, unsupportedVersion);
+    EXPECT_THROW(nc::asset::DeserializeTexture(stream), nc::NcError);
 }

--- a/test/ncasset/CMakeLists.txt
+++ b/test/ncasset/CMakeLists.txt
@@ -25,3 +25,31 @@ target_link_libraries(GetAssetType_unit_tests
 )
 
 add_test(GetAssetType_unit_tests GetAssetType_unit_tests)
+
+### Version Tests ###
+add_executable(Version_unit_tests
+    GetAssetType_unit_tests.cpp
+)
+
+target_compile_options(Version_unit_tests
+    PUBLIC
+        ${NC_TOOLS_COMPILE_OPTIONS}
+)
+
+target_include_directories(Version_unit_tests
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+)
+
+target_sources(Version_unit_tests
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/source/ncasset/NcaHeader.cpp
+)
+
+target_link_libraries(Version_unit_tests
+    PRIVATE
+        gtest_main
+        NcUtility
+)
+
+add_test(Version_unit_tests Version_unit_tests)

--- a/test/ncasset/Version_unit_tests.cpp
+++ b/test/ncasset/Version_unit_tests.cpp
@@ -1,0 +1,17 @@
+#include "NcaHeader.h"
+#include "gtest/gtest.h"
+
+TEST(VersionTests, IsVersionSupported_version3_returnsTrue)
+{
+    EXPECT_TRUE(nc::asset::IsVersionSupported(nc::asset::version3));
+}
+
+TEST(VersionTests, IsVersionSupported_currentVersion_returnsTrue)
+{
+    EXPECT_TRUE(nc::asset::IsVersionSupported(nc::asset::currentVersion));
+}
+
+TEST(VersionTests, IsVersionSupported_badVersion_returnsFalse)
+{
+    EXPECT_FALSE(nc::asset::IsVersionSupported(1ull));
+}

--- a/test/ncasset/Version_unit_tests.cpp
+++ b/test/ncasset/Version_unit_tests.cpp
@@ -1,9 +1,9 @@
 #include "NcaHeader.h"
 #include "gtest/gtest.h"
 
-TEST(VersionTests, IsVersionSupported_version3_returnsTrue)
+TEST(VersionTests, IsVersionSupported_version4_returnsTrue)
 {
-    EXPECT_TRUE(nc::asset::IsVersionSupported(nc::asset::version3));
+    EXPECT_TRUE(nc::asset::IsVersionSupported(nc::asset::version4));
 }
 
 TEST(VersionTests, IsVersionSupported_currentVersion_returnsTrue)


### PR DESCRIPTION
resolves [#412](https://github.com/NcStudios/NcEngine/issues/412)

Adding version info to nca files. The assetId value is unused, so I'm repurposing it to hold the version. I've also replaced a few `size_t` data members with `uint64_t`, since fixed-width types are more appropriate for serialization.